### PR TITLE
chore: upgrade Devlead.Console and align command override visibility

### DIFF
--- a/src/Devlead.Console.Template/DevleadConsole.Tests/DevleadConsole.Tests.csproj
+++ b/src/Devlead.Console.Template/DevleadConsole.Tests/DevleadConsole.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Devlead.Testing.MockHttp" Version="2026.5.15.777" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.10.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.6.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.54.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.55.2" />
     <PackageReference Include="verify.Nunit" Version="31.16.3" />
   </ItemGroup>
 

--- a/src/Devlead.Console.Template/DevleadConsole/Commands/ConsoleCommand.cs
+++ b/src/Devlead.Console.Template/DevleadConsole/Commands/ConsoleCommand.cs
@@ -3,7 +3,7 @@ namespace DevleadConsole.Commands;
 public class ConsoleCommand(ILogger<ConsoleCommand> logger)
     : AsyncCommand<ConsoleSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, ConsoleSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ConsoleSettings settings, CancellationToken cancellationToken)
     {
         logger.LogInformation("Mandatory: {Mandatory}", settings.Mandatory);
         logger.LogInformation("Optional: {Optional}", settings.Optional);

--- a/src/Devlead.Console.Template/DevleadConsole/DevleadConsole.csproj
+++ b/src/Devlead.Console.Template/DevleadConsole/DevleadConsole.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlead.Console" Version="2026.2.11.575" />
+    <PackageReference Include="Devlead.Console" Version="2026.5.15.709" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bump Devlead.Console to 2026.5.15.709 and refresh test dependencies (Microsoft.Extensions.Diagnostics.Testing 10.6.0 for net10.0, Spectre.Console.Testing 0.55.2).

Change ConsoleCommand.ExecuteAsync from public override to protected override to match the updated Devlead.Console base API.